### PR TITLE
fixes glog not outputing info category.

### DIFF
--- a/internal/glog/production_logger.go
+++ b/internal/glog/production_logger.go
@@ -29,7 +29,7 @@ import (
 )
 
 func productionLogger(category enums.LogCategory, msg string, args ...interface{}) {
-	if category == enums.Info {
+	if category == enums.Debug {
 		return
 	}
 	formattedMessage := fmt.Sprintf(msg, args...)


### PR DESCRIPTION
glog logger originally ignored info category in non-debug build. 