### PR TITLE
feat(core): removes the need to use the [apply] before action command

### DIFF
--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -11,65 +11,64 @@ func TestParseApplyCommand(t *testing.T) {
 	testCases := []struct {
 		name     string
 		expected any
-		request  applyCommandArgs
+		request  CommandArgs
 	}{
 		{
 			name:     "Only Key",
 			expected: "0002",
-			request:  applyCommandArgs{connKey: "test"},
+			request:  CommandArgs{connKey: "test"},
 		},
 		{
 			name:     "Only Value",
 			expected: nil,
-			request:  applyCommandArgs{connString: "test"},
+			request:  CommandArgs{connString: "test"},
 		},
 		{
 			name:     "Empty Key Value",
 			expected: "0001",
-			request:  applyCommandArgs{},
+			request:  CommandArgs{},
 		},
 		{
 			name:     "Only From",
 			expected: nil,
-			request:  applyCommandArgs{fromTag: "000", connString: "test"},
+			request:  CommandArgs{fromTag: "000", connString: "test"},
 		},
 		{
 			name:     "Only To",
 			expected: nil,
-			request:  applyCommandArgs{toTag: "000", connString: "test"},
+			request:  CommandArgs{toTag: "000", connString: "test"},
 		},
 		{
 			name:     "From To",
 			expected: nil,
-			request:  applyCommandArgs{fromTag: "000", toTag: "001", connString: "test"},
+			request:  CommandArgs{fromTag: "000", toTag: "001", connString: "test"},
 		},
 		{
 			name:     "Cherry Pick",
 			expected: nil,
-			request:  applyCommandArgs{cherryPickedVersions: []string{"001"}, connString: "test"},
+			request:  CommandArgs{cherryPickedVersions: []string{"001"}, connString: "test"},
 		},
 		{
 			name:     "Cherry Pick and To",
 			expected: "0003",
-			request:  applyCommandArgs{cherryPickedVersions: []string{"000"}, toTag: "001", connString: "test"},
+			request:  CommandArgs{cherryPickedVersions: []string{"000"}, toTag: "001", connString: "test"},
 		},
 		{
 			name:     "Cherry Pick and From",
 			expected: "0003",
-			request:  applyCommandArgs{cherryPickedVersions: []string{"000"}, fromTag: "001", connString: "test"},
+			request:  CommandArgs{cherryPickedVersions: []string{"000"}, fromTag: "001", connString: "test"},
 		},
 		{
 			name:     "Cherry Pick and From and To",
 			expected: "0003",
-			request:  applyCommandArgs{cherryPickedVersions: []string{"000"}, fromTag: "001", toTag: "003", connString: "test"},
+			request:  CommandArgs{cherryPickedVersions: []string{"000"}, fromTag: "001", toTag: "003", connString: "test"},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			applyRequest = tc.request
 
-			err := parseApplyCommand()
+			err := parseApplyCommand(&tc.request)
 			if err == nil {
 				if err == tc.expected {
 					return

--- a/cmd/apply/helpers.go
+++ b/cmd/apply/helpers.go
@@ -42,7 +42,7 @@ import (
 //
 // Params:
 //   - data: pointer to a map of delta tags to raw SQL bytes; will be mutated directly
-func PruneNoOpUp(data *map[int]upDelta) {
+func PruneNoOpUp(data *map[int]UpDelta) {
 	var group sync.WaitGroup
 
 	noOps := make(chan int, len(*data))
@@ -140,14 +140,14 @@ func IsNoOpSql(data string) bool {
 	return true
 }
 
-// getRequestedDeltas parses the user's migration flags into a DeltaRequest.
+// GetRequestedDeltas parses the user's migration flags into a DeltaRequest.
 // Converts --from, --to, and --cherry-pick CLI inputs into a structured request.
 //
 // Returns:
 //   - *deltaRequest: the constructed delta request with range or specific tags
 //   - error: non-nil if any tag is not a valid integer
-func (args applyCommandArgs) getRequestedDeltas() (*deltaRequest, error) {
-	var result deltaRequest
+func (args CommandArgs) GetRequestedDeltas() (*DeltaRequest, error) {
+	var result DeltaRequest
 	if args.fromTag != "" {
 		val, err := strconv.Atoi(args.fromTag)
 		if err != nil {
@@ -195,7 +195,7 @@ func (args applyCommandArgs) getRequestedDeltas() (*deltaRequest, error) {
 	return &result, nil
 }
 
-// getAppliedDeltas retrieves applied deltas from the schemer table.
+// GetAppliedDeltas retrieves applied deltas from the schemer table.
 // Queries the database for all applied delta tags and returns them as a map.
 //
 // Params:
@@ -205,7 +205,7 @@ func (args applyCommandArgs) getRequestedDeltas() (*deltaRequest, error) {
 // Returns:
 //   - map[int]bool: a map of applied delta tags where the key is the tag version and value is true
 //   - error: non-nil if the schemer table is missing or a query/scan error occurs
-func getAppliedDeltas(connection *pgx.Conn, ctx context.Context) (map[int]bool, error) {
+func GetAppliedDeltas(connection *pgx.Conn, ctx context.Context) (map[int]bool, error) {
 	if connection == nil {
 		return nil, &errschemer.SchemerErr{
 			Code:    "0020",

--- a/cmd/apply/post_test.go
+++ b/cmd/apply/post_test.go
@@ -16,27 +16,27 @@ func TestLoadPostDeltas(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		request  *deltaRequest
+		request  *DeltaRequest
 		expected map[int]bool
 	}{
 		{
 			name:     "Load_All",
-			request:  &deltaRequest{},
+			request:  &DeltaRequest{},
 			expected: map[int]bool{0: true, 1: true},
 		},
 		{
 			name:     "From_001",
-			request:  &deltaRequest{From: tu.Ptr(1)},
+			request:  &DeltaRequest{From: tu.Ptr(1)},
 			expected: map[int]bool{1: true},
 		},
 		{
 			name:     "To_000",
-			request:  &deltaRequest{To: tu.Ptr(0)},
+			request:  &DeltaRequest{To: tu.Ptr(0)},
 			expected: map[int]bool{0: true},
 		},
 		{
 			name:     "Cherry_pick",
-			request:  &deltaRequest{Cherries: &map[int]bool{1: true}},
+			request:  &DeltaRequest{Cherries: &map[int]bool{1: true}},
 			expected: map[int]bool{1: true},
 		},
 	}
@@ -65,7 +65,7 @@ func TestFetchPostStatuses(t *testing.T) {
 		t.Fatalf("failed to insert mock data: %v", err)
 	}
 
-	expected := map[int]postStatusEnum{0: 1, 1: 0, 2: 2}
+	expected := map[int]PostStatusEnum{0: 1, 1: 0, 2: 2}
 	statuses, err := fetchPostStatuses(tu.SharedConnection, context.Background())
 	if err != nil {
 		t.Fatalf("failed to fetch post statuses: %v", err)
@@ -93,28 +93,28 @@ func TestExecutePostCommand(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		request  applyCommandArgs
-		expected map[int]postStatusEnum
+		request  CommandArgs
+		expected map[int]PostStatusEnum
 	}{
 		{
 			name:     "Apply_All",
-			request:  applyCommandArgs{},
-			expected: map[int]postStatusEnum{0: 2, 1: 2, 2: 0, 3: 0},
+			request:  CommandArgs{},
+			expected: map[int]PostStatusEnum{0: 2, 1: 2, 2: 0, 3: 0},
 		},
 		{
 			name:     "From_001",
-			request:  applyCommandArgs{fromTag: "001"},
-			expected: map[int]postStatusEnum{0: 1, 1: 2, 2: 0, 3: 0},
+			request:  CommandArgs{fromTag: "001"},
+			expected: map[int]PostStatusEnum{0: 1, 1: 2, 2: 0, 3: 0},
 		},
 		{
 			name:     "To_000",
-			request:  applyCommandArgs{toTag: "000"},
-			expected: map[int]postStatusEnum{0: 2, 1: 1, 2: 0, 3: 0},
+			request:  CommandArgs{toTag: "000"},
+			expected: map[int]PostStatusEnum{0: 2, 1: 1, 2: 0, 3: 0},
 		},
 		{
 			name:     "Cherry_pick",
-			request:  applyCommandArgs{cherryPickedVersions: []string{"000", "001"}},
-			expected: map[int]postStatusEnum{0: 2, 1: 2, 2: 0, 3: 0},
+			request:  CommandArgs{cherryPickedVersions: []string{"000", "001"}},
+			expected: map[int]PostStatusEnum{0: 2, 1: 2, 2: 0, 3: 0},
 		},
 	}
 
@@ -125,7 +125,7 @@ func TestExecutePostCommand(t *testing.T) {
 				t.Fatalf("failed to insert mock data: %v", err)
 			}
 
-			applyRequest = tc.request
+			postRequest = tc.request
 			if err := executePostCommand(tu.SharedConnection, context.Background()); err != nil {
 				t.Fatalf("failed to execute post command: %v", err)
 			}
@@ -137,11 +137,11 @@ func TestExecutePostCommand(t *testing.T) {
 			}
 			defer rows.Close()
 
-			actual := map[int]postStatusEnum{}
+			actual := map[int]PostStatusEnum{}
 
 			for rows.Next() {
 				var tag int
-				var status postStatusEnum
+				var status PostStatusEnum
 				if err := rows.Scan(&tag, &status); err != nil {
 					t.Fatalf("failed to scan row: %v", err)
 				}

--- a/cmd/apply/poststatusenum_string.go
+++ b/cmd/apply/poststatusenum_string.go
@@ -17,8 +17,8 @@ const _postStatusEnum_name = "NoExistPendingApplied"
 
 var _postStatusEnum_index = [...]uint8{0, 7, 14, 21}
 
-func (i postStatusEnum) String() string {
-	if i < 0 || i >= postStatusEnum(len(_postStatusEnum_index)-1) {
+func (i PostStatusEnum) String() string {
+	if i < 0 || i >= PostStatusEnum(len(_postStatusEnum_index)-1) {
 		return "postStatusEnum(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _postStatusEnum_name[_postStatusEnum_index[i]:_postStatusEnum_index[i+1]]

--- a/cmd/apply/types.go
+++ b/cmd/apply/types.go
@@ -23,11 +23,11 @@ package apply
 
 //go:generate stringer -type=postStatusEnum
 
-// applyCommandArgs holds parsed CLI arguments for a migration command.
+// CommandArgs holds parsed CLI arguments for a migration command.
 // Note: the meaning of toTag and fromTag depends on the command type:
 //   - For "up": fromTag is the lower bound, toTag is the upper bound.
 //   - For "down": fromTag is the upper bound, toTag is the lower bound.
-type applyCommandArgs struct {
+type CommandArgs struct {
 	dryRun               bool     // if true, prints actions without executing them
 	PruneNoOp            bool     // if true, skips deltas that are no-ops
 	connKey              string   // the environment key to retirve the PostgreSQL connection string. Ignored if connString is passed.
@@ -37,7 +37,7 @@ type applyCommandArgs struct {
 	cherryPickedVersions []string // specific delta tags to apply instead of a range
 }
 
-// deltaRequest defines the range or specific set of deltas to apply.
+// DeltaRequest defines the range or specific set of deltas to apply.
 //
 // For an "up" command:
 //   - From is the lower bound (inclusive)
@@ -48,7 +48,7 @@ type applyCommandArgs struct {
 //   - To is the lower bound (inclusive)
 //
 // If Cherries is set, it overrides From/To and applies only the specified tags.
-type deltaRequest struct {
+type DeltaRequest struct {
 	To       *int          // tag boundary (upper for up, lower for down)
 	From     *int          // tag boundary (lower for up, upper for down)
 	Cherries *map[int]bool // specific delta tags to apply; overrides From/To if set
@@ -56,34 +56,34 @@ type deltaRequest struct {
 }
 
 // Represents user input for post command.
-type postCmdRequest struct {
+type PostForce struct {
 	Force bool // allow applying post deltas even if not registered in schemer
 }
 
-// postStatusEnum represents the state of a post delta.
+// PostStatusEnum represents the state of a post delta.
 //
 // Possible values:
 //   - 0: NoExist (no associated post delta)
 //   - 1: Pending (post delta exists but hasn't been applied)
 //   - 2: Applied (post delta has been executed)
-type postStatusEnum int
+type PostStatusEnum int
 
 const (
-	NoExist postStatusEnum = iota // no associated post delta
+	NoExist PostStatusEnum = iota // no associated post delta
 	Pending                       // post delta exists but has not been applied
 	Applied                       // post delta has been successfully applied
 )
 
-// postDelta represents a post-migration delta and its metadata.
-type postDelta struct {
+// PostDelta represents a post-migration delta and its metadata.
+type PostDelta struct {
 	Tag        int            // unique identifier of the delta
 	Data       []byte         // raw SQL content of the post delta
-	PostStatus postStatusEnum // current post status (e.g., Pending, Applied)
+	PostStatus PostStatusEnum // current post status (e.g., Pending, Applied)
 }
 
-// upDelta represents a forward (up) delta and its metadata.
-type upDelta struct {
+// UpDelta represents a forward (up) delta and its metadata.
+type UpDelta struct {
 	Tag        int            // unique identifier of the delta
 	Data       []byte         // raw SQL content of the up delta
-	PostStatus postStatusEnum // post delta status (e.g., NoExist, Pending)
+	PostStatus PostStatusEnum // post delta status (e.g., NoExist, Pending)
 }

--- a/cmd/apply/up_test.go
+++ b/cmd/apply/up_test.go
@@ -19,13 +19,13 @@ func TestLoadUpDeltas(t *testing.T) {
 
 	testCases := []struct {
 		name    string
-		request *deltaRequest
-		verify  func(args *deltaRequest)
+		request *DeltaRequest
+		verify  func(args *DeltaRequest)
 	}{
 		{
 			name:    "valid_post_status",
-			request: &deltaRequest{},
-			verify: func(args *deltaRequest) {
+			request: &DeltaRequest{},
+			verify: func(args *DeltaRequest) {
 				deltas, err := loadUpDeltas(args)
 				if err != nil {
 					t.Fatalf("loadUpDeltas failed: %v", err)
@@ -42,10 +42,10 @@ func TestLoadUpDeltas(t *testing.T) {
 		},
 		{
 			name: "Cherry_Pick",
-			request: &deltaRequest{
+			request: &DeltaRequest{
 				Cherries: &map[int]bool{1: true, 3: true},
 			},
-			verify: func(args *deltaRequest) {
+			verify: func(args *DeltaRequest) {
 				deltas, err := loadUpDeltas(args)
 				if err != nil {
 					t.Fatalf("loadUpDeltas failed: %v", err)
@@ -63,8 +63,8 @@ func TestLoadUpDeltas(t *testing.T) {
 		},
 		{
 			name:    "From_002",
-			request: &deltaRequest{From: tu.Ptr(2)},
-			verify: func(args *deltaRequest) {
+			request: &DeltaRequest{From: tu.Ptr(2)},
+			verify: func(args *DeltaRequest) {
 				deltas, err := loadUpDeltas(args)
 				if err != nil {
 					t.Fatalf("loadUpDeltas failed: %v", err)
@@ -82,8 +82,8 @@ func TestLoadUpDeltas(t *testing.T) {
 		},
 		{
 			name:    "To_001",
-			request: &deltaRequest{To: tu.Ptr(1)},
-			verify: func(args *deltaRequest) {
+			request: &DeltaRequest{To: tu.Ptr(1)},
+			verify: func(args *DeltaRequest) {
 				deltas, err := loadUpDeltas(args)
 				if err != nil {
 					t.Fatalf("loadUpDeltas failed: %v", err)
@@ -115,11 +115,11 @@ func TestApplyUpDeltas(t *testing.T) {
 	utils.GetDeltaPath = func() (string, error) {
 		return tempDir, nil
 	}
-	applyRequest = applyCommandArgs{PruneNoOp: false}
+	upRequest = CommandArgs{PruneNoOp: false}
 
-	deltas := map[int]upDelta{
-		0: upDelta{Tag: 0, Data: []byte(""), PostStatus: Pending},
-		1: upDelta{Tag: 1, Data: []byte(""), PostStatus: NoExist},
+	deltas := map[int]UpDelta{
+		0: UpDelta{Tag: 0, Data: []byte(""), PostStatus: Pending},
+		1: UpDelta{Tag: 1, Data: []byte(""), PostStatus: NoExist},
 	}
 	applied := map[int]bool{}
 
@@ -143,7 +143,7 @@ func TestApplyUpDeltas(t *testing.T) {
 
 	for rows.Next() {
 		var tag int
-		var status postStatusEnum
+		var status PostStatusEnum
 
 		if err := rows.Scan(&tag, &status); err != nil {
 			t.Fatalf("row scan failed: %v", err)
@@ -177,7 +177,7 @@ func TestExecuteUpCommand(t *testing.T) {
 		return tempDir, nil
 	}
 
-	applyRequest = applyCommandArgs{
+	upRequest = CommandArgs{
 		cherryPickedVersions: []string{"000", "002"},
 	}
 
@@ -200,14 +200,14 @@ func TestExecuteUpCommand(t *testing.T) {
 		t.Fatalf("failed to verify deltas applied: %v", err)
 	}
 
-	deltas := map[int]postStatusEnum{
+	deltas := map[int]PostStatusEnum{
 		1: Pending,
 		2: NoExist,
 	}
 
 	for rows.Next() {
 		var tag int
-		var status postStatusEnum
+		var status PostStatusEnum
 
 		rows.Scan(&tag, &status)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,12 @@ Typical usage:
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		glog.InitializeLogger(false)
+
+		if os.Getenv("SCHEMER_ENV") == "local" {
+
+		} else {
+			glog.InitializeLogger(false)
+		}
 	},
 }
 


### PR DESCRIPTION
Using apply as a parent command became annoying.
This will allow you to user [schemer <up,down,post> options] and no longer include apply as a parent command.